### PR TITLE
Western Coordinates Option Added | Custom MLO PED Issue Solved

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -178,14 +178,14 @@ RegisterNetEvent('cqc-mugshot:client:trigger', function()
         Wait(250)
         MakeBoard()
         MugShotCamera()
-        SetEntityCoords(ped, suspectx, suspecty, suspectz)
-        SetEntityHeading(ped, suspectheading)
+        SetEntityCoords(suspectx, suspecty, suspectz, ped)
+        SetEntityHeading(suspectheading, ped)
         PlayerBoard()
         TaskPlayAnim(ped, animDict, "loop_raised", 8.0, 8.0, -1, 49, 0, false, false, false)
         PhotoProcess(ped)
         if createdCamera ~= 0 then
             DestoryCamera()
-            SetEntityHeading(ped, suspectheading)
+            SetEntityHeading(suspectheading, ped)
             ClearPedSecondaryTask(GetPlayerPed(ped))
         end
         if Config.CQCMDT then

--- a/config.lua
+++ b/config.lua
@@ -13,6 +13,21 @@ Config.MugShotCamera = {
     r = {x = 0.0, y = 0.0, z = 110.33} -- To change the rotation use the z. Others are if you want rotation on other axis
 }
 
+--[[
+
+If using Western's MRPD the Coordinates are as following,
+
+Config.MugshotLocation = vector3(484.0772, -999.4976, 25.4675) -- Location of the Suspect
+Config.MugshotSuspectHeading = 357.8132 -- Direction Suspsect is facing
+Config.MugShotCamera = {
+    x = 484.0522,
+    y = -997.6379,
+    z = 25.4675,
+    r = {x = 0.0, y = 0.0, z = 177.5} -- To change the rotation use the z. Others are if you want rotation on other axis
+}
+
+]]
+
 Config.BoardHeader = "Los Santos Police Department" -- Header that appears on the board
 Config.WaitTime = 2000 -- Time before and after the photo is taken. Decreasing this value might result in some angles being skiped.
 Config.Photos = 3 -- Front, Back Side. Use 4 for both sides


### PR DESCRIPTION
The Placement of the 'ped' within the SetEntityCoords and SetEntityHeading wasn't proper. As well, I placed a Hashed Config for users to have a useable Western's PD Config. This can be taken and tossed into a ReadMe or any .mb file that you all choose of.